### PR TITLE
Add the new handbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# handbook
-The guide to running, operating, and being a part of Pryaxis.
+# Pryaxis Operator's Manual
 
-This guide contains the opreating policy of Pryaxis. Until the first pull request is agreed on, this is not an official guide. This message will be removed when it becomes official.
+This is the open source manual for the Pryaxis organization. More specifically, this guide contains everything needed to know:
+
+* What Pryaxis is, on a more formal level.
+* How Pryaxis operates and who makes the decisions.
+* How to perform technical procedures, like updating TShock.
+
+## What is Pryaxis [the organization]?
+
+Pryaxis is kind of a loose collection of people that have had several names. Originally, it was called _The TShock Team_, as it was primarily the team that developed TShock. When we realized that we might want to do something other than TShock, we picked _Nyx Studios_ as our next name. Now, we go by _Pryaxis_. Effectively, we're an open source development crew with hopefully some added perks, once we can get our act together and get some free time.
+
+## Who is Pryaxis?
+
+See ```members.md```. It's anyone in that file, organized by how that file works.

--- a/consensus.md
+++ b/consensus.md
@@ -1,0 +1,15 @@
+# Consensus
+
+We try to make decisions as a group. In the TShock project, we have a two-man rule on code review. This is discussed in more detail in that project, but:
+
+* Two people must sign off on code for it to go in. If the code is internal (from another leader), you just need one more sign-off to get it merged. Please respect if someone requests changes: that doesn't mean get approval and go around, it means work with them to turn their denial to approval.
+* Two leaders must review external code. This is technically three sets of eyes. If you're the second leader reviewing code, and you feel comfortable, you can merge it. If you don't -- that's okay, just approve it and move on.
+
+In non-code activities, we try to reach an "ad-hoc" majority consensus. This is a really loose, trust based decision system:
+
+* We poll people who are available, in a reasonable amount of time, to make a decision in high charity.
+* If the majority of the people polled are in favor of an action, it happens.
+
+A reasonable amount of time is defined as "about three days." If you're the one trying to get a decision made, it's your job to reach out to people to get them to chime in.
+
+Finally, we err on the side of trust with our decisions. If a consensus was reached and we made a decision, we try not to go back on it later. We haven't been the best about this in the past, especially with kicking and banning troublesome members, but we should strive to be more consistent. Unless outstanding circumstances apply, we should strive to not reverse decisions made as a collective unless absolutely necessary.

--- a/members.md
+++ b/members.md
@@ -35,6 +35,7 @@ Leaders of Pryaxis are the people who run the operation. Every leader is equival
   * Is legal data handler concerning stats data in the UK.
 * @Deathmax (Discord: Deathmax#7906)
 * @Enerdy (Discord: Enerdy#8912)
+  * Has Twitter access.
 * @MarioE (Discord: marioe#7557)
 * @Patrikkk (Discord: Patrikk#4016)
 * @mistzzt (Discord: mist#3706)

--- a/members.md
+++ b/members.md
@@ -56,3 +56,7 @@ Guests in the #high-charity Discord room have the technical capacity to, in the 
 # What if the root users disappear?
 
 If a leader can't reach a root user that's important, then it's imperative that all systems remain online and operational. All roles previously assigned to root only users are now up for grabs by anyone, with the two-man rule in place. We currently have no recovery plan if all three root users are hit by a bus, or if @hakusaro is hit by a bus and literally nobody else has access to ```arc```. We're working on this!
+
+# What if a leader disappears?
+
+If you can't reach someone, bring it up in this repo with an issue or in #high-charity. On a case by case basis, we'll discuss moving them out of the leadership role they sit in temporarily. If they need to take a leave of absence, we can just keep them around with limited permissions until they're a-okay again.

--- a/members.md
+++ b/members.md
@@ -35,7 +35,7 @@ Leaders of Pryaxis are the people who run the operation. Every leader is equival
   * Is legal data handler concerning stats data in the UK.
 * @Deathmax (Discord: Deathmax#7906)
 * @Enerdy (Discord: Enerdy#8912)
-  * Has Twitter access.
+  * Has Twitter account access.
 * @MarioE (Discord: marioe#7557)
 * @Patrikkk (Discord: Patrikk#4016)
 * @mistzzt (Discord: mist#3706)

--- a/members.md
+++ b/members.md
@@ -1,0 +1,58 @@
+# Who are the members of Pryaxis?
+
+This section is kind of built in the principle that we can add more non-leaders in the future. Right now, it's just leaders and guests. Every person that can see #high-charity is either a leader or a guest.
+
+<!-- Make sure, when editing this document, that you always list GitHub usernames as the first thing, followed by their Discord nickname. -->
+
+Other documents make reference only to "leaders." Leaders includes both the root users and the leaders, for simplicity sake. Except where explicitly called out, all leaders and root users are effectively at the same "rank" in most operations.
+
+When a leader posts on the forums, replies to an issue on GitHub, or chats in Discord, they're speaking on the same playing field as everyone else.
+
+## Root Users
+
+The people listed as root have been with Pryaxis consistently and reliably for a long time. They're considered the rotating highest point of contact. Major policy decisions require them to approve or at least abstain on the decision. These members typically have the highest technical leadership as well as other more nuanced roles associated with them. In effect, root users are the "sysadmins" of our organization.
+
+All root users have the root role on Discord, which grants "Administrator" rights including permission overrides on all actions.
+
+* @hakusaro (Discord: hakusaro#6463)
+  * Operates ```arc```, the server that runs TShock's forums, update server, and other micro services attached to TShock.
+  * Operates most TShock and Pryaxis related domains.
+  * Operates Twitter.
+  * Is an owner of @Pryaxis on GitHub.
+  * Is the Discord owner for TShock.
+* @QuiCM (Discord: Cold#7366)
+  * Is an owner of @Pryaxis on GitHub.
+  * Has Twitter access.
+* @Ijwu (Discord: Ijwu#7209)
+
+## Leaders
+
+Leaders of Pryaxis are the people who run the operation. Every leader is equivalent. Every leader has the _technical_ ability to push code to TShock, though we discourage people from doing so in modern times (we prefer GitHub flow and the two-man rule from now on). The only things they can't do are: publish official TShock updates and perform technical actions they haven't yet been granted access to. We're working on this one.
+
+* @DeathCradle (Discord: death#6133)
+* @Celant (Discord: Jish#0319)
+  * Operates the stat tracker Heroku instance and backend DB.
+  * Is legal data handler concerning stats data in the UK.
+* @Deathmax (Discord: Deathmax#7906)
+* @Enerdy (Discord: Enerdy#8912)
+* @MarioE (Discord: marioe#7557)
+* @Patrikkk (Discord: Patrikk#4016)
+* @mistzzt (Discord: mist#3706)
+  * Due to technical incompetence on the part of @hakusaro, Mist did not get moved to the new Pryaxis org when we made the switch from Nyx. Doh. Currently being fixed.
+* @ProfessorXZ (Discord: Ivan#0667)
+* @tylerjwatson (Discord: wolfje#6084)
+* @Zaicon (Discord: Zaicon#1719)
+  * Due to technical incompetence on the part of @hakusaro, Zaicon did not get moved to the new Pryaxis org when we made the switch from Nyx. Doh. Currently being fixed.
+* DaBomber (Discord: Da Bomber | 폭탄병#9235)
+  * Has Twitter account access.
+
+## Guests
+
+Guests in the #high-charity Discord room have the technical capacity to, in the event of an emergency, act as first responders to disasters. This includes deleting messages, kicking, or banning spammers. They do not have voting rights on decisions we as a group make as a whole, nor do they have the ability to _speak on behalf of Pryaxis_.
+
+* Elliott from Multiplay UK (Nibbler#6533)
+* Re-Logic Staff
+
+# What if the root users disappear?
+
+If a leader can't reach a root user that's important, then it's imperative that all systems remain online and operational. All roles previously assigned to root only users are now up for grabs by anyone, with the two-man rule in place. We currently have no recovery plan if all three root users are hit by a bus, or if @hakusaro is hit by a bus and literally nobody else has access to ```arc```. We're working on this!

--- a/policy/banning.md
+++ b/policy/banning.md
@@ -1,0 +1,27 @@
+# Banning
+
+When someone violates the community code of conduct, or when we decide that a member needs to be removed, we can ban them.
+
+## When do we ban someone?
+
+That depends on a lot of things. If someone breaks the code of conduct or acts erroneously once, a leader should be able to warn the user and stop them from continuing.
+
+Banning should only be a thing that happens when _a user has been warned repeatedly_ about either one subject or many subjects and has yet to understand the implications of being in the community. Banning should be taken as a step to _ensure the community's safety, harmony, and success, as a unit_, not as a punishment as a direct result of an action. It isn't that we ban someone to prove a point, but rather, it's that we ban someone to ensure the future health of the community.
+
+A consensus must be reached prior to ban. These consensus windows should be shorter than three days. If exigent circumstances exist, a temporary ban may be placed while we determine a final verdict on what to do about a situation.
+
+## How do we ban someone?
+
+We should be consistent across all services. A ban on Discord is equivalent to a ban on the forums, as well as an organization block on GitHub.
+
+## When do we reverse bans?
+
+We don't. Or at least, we really shouldn't. In the past, we've had a lot of problems with this. If someone is banned, we should have reached a consensus and kept tabs on why someone is banned or what they did to deserve it.
+
+In general, if we reverse too many bans or if we take into account invalid arguments when reversing bans, it makes our policy less strong. A weak policy is worse than no policy, because it implies that we ourselves are weak. It implies that we, the team, don't have a cohesive voice.
+
+## Ban on sight or turn the other way?
+
+Ban on sight. If it becomes known that someone is using a sock puppet, we should ban the sock puppet and make a note that they were an alternate account of a banned user.
+
+This is a going forward, non-retroactive policy from implementation date. We don't really care about "known alts" that exist under this policy.

--- a/policy/rfc.md
+++ b/policy/rfc.md
@@ -1,0 +1,20 @@
+# RFC Process
+
+When something is unclear, a request for comments can be made. An RFC can be made about a policy, about a policy change, a member of the community, a localized event, or anything else.
+
+RFCs are effectively precedent setting documents that help address nuances not covered in the handbook explicitly. Rather than try to list out every possible thing we can or cannot encounter, RFCs help address questions anyone has, operation wise.
+
+## Required Elements
+
+An RFC needs to have at least three key components:
+
+- A discussion with the leadership team. It can happen over GitHub issues in this repo or in another repo. It can happen in voice chat or over Discord chat.
+- Consensus data. Preferably, we have everything happen for voting on an issue over GitHub using code reviewers. Either way, each RFC needs at least a voting record of who supported the RFC going forward. If it doesn't meet minimum consensus, don't publish it. For sensitive issues, consensus data can be kept private (e.g., rather than listing members present for a meeting about a user's banning, you can just say that 5 team members participated in the decision).
+- Synthesized problem and solution. The problem statement should be as direct as possible and include a bulleted list of deciding factors that led to the decision. The solution should be clear and direct too. One person can make this synthesis.
+
+The RFC must be put in this repo to become official. If all three ingredients are included, the final RFC document can just be put in the rfc folder directly. Name it something sensible like ```date-rfc-topic.md```.
+
+If the RFC discussion or consensus data is happening over GitHub, it should take the form of a pull request and issue combination.
+
+An RFC is not official unless it has a clear consensus, discussion, and a synthesized problem and solution. It also has to be in this repo.
+

--- a/policy/rfc.md
+++ b/policy/rfc.md
@@ -18,3 +18,5 @@ If the RFC discussion or consensus data is happening over GitHub, it should take
 
 An RFC is not official unless it has a clear consensus, discussion, and a synthesized problem and solution. It also has to be in this repo.
 
+The final document is what counts. How you get there is a different story: if there's a consensus and you did it via email, that's a bit arcane but it does work. GitHub is convenient for some but not others, and sometimes the decision is obvious (e.g., everyone was in voice chat and we don't want to make an issue and leave comments just to be pedantic).
+

--- a/trust.md
+++ b/trust.md
@@ -1,0 +1,9 @@
+# Trust
+
+When TShock started, @hakusaro gave write access to the repository to anyone who contributed positively to TShock on their first pull request. We didn't filter people based on any formal application or anything -- in fact, the original ambition was inherently trusting. We trust our leaders just like we trusted people when they were added on the first pull request.
+
+If a fellow leader makes a decision, we can reasonably assume they did so in good faith. If a group of leaders make a decision in consensus, we can assume that group did so in good faith. 
+
+Even when we've had drama in the community, we've never had a leader "go rogue" and act in self interest. We've never had a trust ending event, and we'd like to keep it that way. To keep it that way, just make sure that you understand that we're a small collective of quasi-independent open source developers. Some of us have a lot of free time, and some have very little. Some are active in Discord daily, while some are busy with life. That's okay. Just make sure that you trust your fellow leaders to take the reigns if you aren't around.
+
+We tend to err on the side of having multiple sources of recovery if a single person goes absent. We try to distribute power to people and add resiliency, which, by extension, means people need to be trusting of one another with decentralized power. While everyone has write access to TShock, for example, we expect that power to not be used unless in an emergency or in a special circumstance. We trust you to not blow away our hard work.


### PR DESCRIPTION
Hiya, I'm Lucas. I'm proposing a series of formal policies to replace our old framework for operating the TShock project & associated repositories.

At a glance, this handbook:

* Attempts to clarify the role of leaders.
* Attempts to clarify how we make decisions as leaders.
* Attempts to create a set of unified policy guidelines we can follow in the future.
* **Formally resets permissions for all leaders to the new baseline.**
  * If (and when) this pull request is merged, the associated members list will become the official policy and set of members. This structure is _implied_ as of now, but we want to make it _explicit_ or _explicitly revert to a more conservative policy_ with this PR too.

Currently done:

- [x] Membership document
- [x] Consensus document
- [x] Trust document
- [x] Readme

Currently todo:

- [x] Policy folder with policy on banning
- [x] A micro-RFC process to get policy clarification with consensus
- [ ] A technical guide to updating TShock

I want feedback from everyone on this. I really do aim to get everyone, but if we can't get everyone, we're going to follow the guidance I have in ```consensus.md``` to try and get this policy implemented by Tuesday, August 22, 2017.
